### PR TITLE
addTrainerAlertFix: removed alert() call, added span that displays success or failure

### DIFF
--- a/src/app/User/user/Components/add-trainer/add-trainer.component.html
+++ b/src/app/User/user/Components/add-trainer/add-trainer.component.html
@@ -44,7 +44,9 @@
                     </div>
               </div>
           <div class="modal-footer">
-            <button id="updateButton1" type="submit" value="Submit" class="btn btn-primary" (click)="addTrainer()" data-dismiss="modal">Submit</button>
+            <span class = "fa-pull-left" style = " color: green;" *ngIf = "displaySuccess" [innerText] = "displaySuccessMsg"></span>
+            <span class = "fa-pull-left" style = " color: red;" *ngIf = "displayFailure" [innerText] = "displayFailureMsg"></span>
+            <button id="updateButton1" type="submit" value="Submit" class="btn btn-primary" (click)="addTrainer()">Submit</button>
             <button id="closeButton1" type="button" class="btn btn-default" data-dismiss="modal" (click)="closeAddTrainerModal()" >Close</button>
           </div>
         </form>

--- a/src/app/User/user/Components/add-trainer/add-trainer.component.ts
+++ b/src/app/User/user/Components/add-trainer/add-trainer.component.ts
@@ -16,26 +16,46 @@ export class AddTrainerComponent implements OnInit {
   }
 
   private newTrainer:Trainer = new Trainer();
+
+  displaySuccess:boolean;
+
+  displayFailure:boolean;
+
+  displaySuccessMsg:String;
+
+  displayFailureMsg:String;
   
   addTrainer()
   {
     this.trainerServ.addTrainer(this.newTrainer).subscribe(response => 
     {
-      alert("Trainer added successfully!");
-      window.location.reload();
+      this.toggleSuccessMsgDisplay();
+      this.displaySuccessMsg = "Trainer added successfully!";
+      //window.location.reload();
     }, error => {
-      const serviceName = 'User Service ';
-      const errorMessage = 'Failed to add trainer to database! Please fill out all fields correctly, and give a unique email.';
-      this.errorService.setError(serviceName, errorMessage);
-      this.closeAddTrainerModal();
+
+      this.toggleFailureMsgDisplay();
+      this.displayFailureMsg = "Failed to add trainer to database! Please fill out all fields correctly, and give a unique email.";
+      //this.closeAddTrainerModal();
     });
 
+  }
+
+  toggleSuccessMsgDisplay()
+  {
+    this.displayFailure = false;
+    this.displaySuccess = true;
+  }
+
+  toggleFailureMsgDisplay() 
+  {
+    this.displaySuccess = false;
+    this.displayFailure = true;
   }
 
   closeAddTrainerModal()
   {
     this.resetAddTrainerForm();
-
   }
 
   resetAddTrainerForm() 
@@ -52,6 +72,12 @@ export class AddTrainerComponent implements OnInit {
     this.newTrainer.email = "";
     this.newTrainer.tier = "";
     this.newTrainer.password = "";
+
+    this.displayFailure = false;
+    this.displaySuccess = false;
+
+    this.displayFailureMsg = "";
+    this.displaySuccessMsg = "";
 
   }
   

--- a/src/app/User/user/Components/view-trainers/view-trainers.component.ts
+++ b/src/app/User/user/Components/view-trainers/view-trainers.component.ts
@@ -40,7 +40,6 @@ export class ViewTrainersComponent implements OnInit {
    */
   displayTrainerUpdateModal(trainer: Trainer) {
     this.EditTrainer.displayTrainer(trainer);
-
   }
 
   getAllTrainers() 


### PR DESCRIPTION
This addresses the issue described in this link: [https://github.com/revaturelabs/caliber-2-meta/issues/104](url)

I removed the alert() call, created a span in the addTrainer modal whose purpose is to show messages depending on whether or not adding the trainer was successful. 

The submit button also no longer closes the modal.